### PR TITLE
Voeg minimum stringlengte toe aan Identificatiecode

### DIFF
--- a/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/openapi.yaml
+++ b/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/openapi.yaml
@@ -1626,6 +1626,7 @@ components:
     Identificatiecode:
       type: "string"
       description: "Unieke technische identificerende code, primair bedoeld voor gebruik bij interacties tussen IT-systemen."
+      minLength: 1
       maxLength: 40
     IndicatieJaNee:
       type: "boolean"


### PR DESCRIPTION
Het `Identificatiecode` schema wordt op diverse endpoints als path parameter gebruikt:

  - /externeregisters/{code}
  - /kanalen/{code}
  - /landen/{code}
  - /soortendigitaaladres/{code}
  - /soortenobject/{code}
  - /soortenobjectid/{code}
  - /talen/{code}

Voor objecten met een lege string als code zouden de paden voor operaties op dat object, verwarrend dicht bij de operaties op de lijsten van dat type object komen:

  - /externeregisters/
  - /kanalen/
  - /landen/
  - /soortendigitaaladres/
  - /soortenobject/
  - /soortenobjectid/
  - /talen/

versus

  - /externeregisters
  - /kanalen
  - /landen
  - /soortendigitaaladres
  - /soortenobject
  - /soortenobjectid
  - /talen

In combinatie met het bestaan van regels in sommige http server configuraties die automatisch slashes toevoegen aan het einde van paden kan dit voor grote verwarring zorgen.

# NB

Voor de schemas `Naam-kort` en `Omschrijving-kort` heb ik m'n vragen bij de semantische waarde van een lege string. Uit de png'tjes van het semantische model is dit ook niet duidelijk. Wellicht iets om over te buigen bij de behandeling van #270
