### PR TITLE
Referentielijsten voorbeeldvulling

### DIFF
--- a/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/voorbeeldvulling-referentielijsten.md
+++ b/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/voorbeeldvulling-referentielijsten.md
@@ -53,21 +53,17 @@ Voorstel voor vulling van de referentielijst "Soorten digitaal adres"
 
 ## Taal
 
-Er is een internationale Standaard beschikbaar de ISO 639:2023 standaard. Deze standaard heeft recentelijk de volgende lijst standaarden vervangen : 
-ISO 639-1:2002 - Codes for the representation of names of languages — Part 1: Alpha-2 code
-ISO 639-5:2008 - Codes for the representation of names of languages — Part 5: Alpha-3 code for language families and groups
-ISO 639-3:2007 - Codes for the representation of names of languages — Part 3: Alpha-3 code for comprehensive coverage of languages
-ISO 639-2:1998 - Codes for the representation of names of languages — Part 2: Alpha-3 code
-ISO 639-4:2010 - Codes for the representation of names of languages — Part 4: General principles of coding of the representation of names of languages and related entities, and application guidelines
+Voor de voorbeeldvulling van de talenlijst wordt een selectie de ISO 639-2 lijst gebruikt zoals die gepubliceerd is door de [Library of Congress](https://www.loc.gov/standards/iso639-2/php/code_list.php). Van deze lijst wordt de drie-letterige code toegepast als code in de referentielijst. Waar er voor een taal 2 codes zijn gedefinieerd wordt de (T)-variant gebruikt in de referentielijst. 
 
-Voor de talenlijst die hier benodigd is zou ISO 639-1:2002 waarschijnlijk afdoende zijn. 
-De ISO 639:2023 standaard zou aangeschaft moeten worden. Hoe gaan we hier mee om ? (https://standards.iteh.ai/catalog/standards/iso/ead9cc68-1fda-4225-add7-a24dabf3f742/iso-639-2023)
+Voor het samenstellen van de lijst worden de volgende criteria gehanteerd :
+- De door de overheid [erkende talen van Nederland](https://www.rijksoverheid.nl/onderwerpen/erkende-talen/vraag-en-antwoord/erkende-talen-nederland).
+- [De officiële talen van de Europese Unie](https://european-union.europa.eu/principles-countries-history/languages_nl)
+- De meest-gesproken talen in Nederland.
 
-Voorstel is om vooralsnog de ISO 639-1:2002 lijst te hanteren. Die is [hier](https://nl.wikipedia.org/wiki/Lijst_van_ISO_639-codes) op te halen. 
+Dat leidt tot de volgende voorbeeldvulling van de referentielijst
 
-Alleen die talen waar een waarde in de kolom "639-1" staat worden opgenomen. 
+| **Code** | **Naam** | **IndicatieActief** | 
 
-Als `code` wordt de twee-letterige code in de kolom "639-1"uit de Tabel op [Wikipedia, Lijst van ISO 639-codes]https://nl.wikipedia.org/wiki/Lijst_van_ISO_639-codes) overgenomen.
 
 Als `naam` wordt de "Taalnaam" overgenomen.
 

--- a/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/voorbeeldvulling-referentielijsten.md
+++ b/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/voorbeeldvulling-referentielijsten.md
@@ -1,0 +1,93 @@
+---
+layout: page-with-side-nav
+title: Voorbeeldvulling voor referentilijsten bij klantinteracties
+date: 29-01-2024
+---
+
+# Inleiding
+
+In principe staat het iedere gemeente vrij om de referentielijsten op te stellen naar eigen inzicht. 
+In dit document wordt voor sommige referentielijsten een basisvulling voorgesteld die aan te vullen is mert gemeentespecifieke waarden. 
+Daarnaast wordt er voor sommige referentielijsten een voorstel gedaan voor de hele inhoud van de referentielijst. 
+
+We adviseren om deze vulling van referentielijsten over te nemen aangezien dit voor de leveranciers een basis kan vormen. 
+Tevens is het een goede zaak als gemeenten onderling voor dezelfde referentielijst waarden ook dezelfde codes gebruikten.
+
+# Referentielijsten
+
+Per referentielijst wordt aangegeven of, en welke (basis-)vulling er is gedefinieerd en op welke wijze er gemeente-specifieke waarden kunnen worden toegevoegd. 
+
+## Kanalen
+
+Vraag uitgezet bij Paul Jansen 
+
+
+| Code | Naam | indicatieActief |
+| :----------- | :----------- | :----------- |
+
+## Landen
+
+Voor de referentielijst landen wordt verwezen naar de landelijke tabel 34 zoals die wordt gepubliceerd door de RVIG. 
+De inhoud van deze tabel is beschikbaar op de site van het RVIG onder [Landelijke tabellen](https://publicaties.rvig.nl/Landelijke_tabellen/) 
+
+Als `landcode` wordt de "Code" van de landelijke tabel 34 overgenomen
+Als `landnaam` wordt de "Omschrijving" van de landelijke tabel 34 overgenomen 
+Als `ingangsdatumLand` wordt de waarde van "Datum Ingang" van de landelijke tabel 34 overgenomen maar wel volgens de volgens de NEN-ISO 8601:2019-standaard genoteerd.
+Als `einddatumLand` wordt de waarde van "Datum Einde" van de landelijke tabel 34 overgenomen maar wel volgens volgens de NEN-ISO 8601:2019-standaard
+
+## Soorten digitaal adres
+
+Voor de soorten digitaal adres is er geen landelijk standaard waarop we kunnen terugvallen. 
+
+Voorstel voor vulling van de referentielijst "Soorten digitaal adres" 
+
+| Code | Naam | 
+| :----------- | :----------- |
+| 1  | Telefoon | 
+| 2  | E-mail |
+| 3  | Whatsapp |
+| 4  | Brief | 
+| 5  | Web formulier | 
+| 6  | Chat-applicatie | 
+| 7  | Baliebezoek | 
+| 8  | Bezoek op afspraak |
+| 9  | Facebook | 
+| 10 | Instagram | 
+
+
+## Talen
+
+Er is een internationale Standaard beschikbaar de ISO 639:2023 standaard. Deze standaard heeft recentelijk de volgende lijst standaarden vervangen : 
+ISO 639-1:2002 - Codes for the representation of names of languages — Part 1: Alpha-2 code
+ISO 639-5:2008 - Codes for the representation of names of languages — Part 5: Alpha-3 code for language families and groups
+ISO 639-3:2007 - Codes for the representation of names of languages — Part 3: Alpha-3 code for comprehensive coverage of languages
+ISO 639-2:1998 - Codes for the representation of names of languages — Part 2: Alpha-3 code
+ISO 639-4:2010 - Codes for the representation of names of languages — Part 4: General principles of coding of the representation of names of languages and related entities, and application guidelines
+
+Voor de talenlijst die hier benodigd is zou ISO 639-1:2002 waarschijnlijk afdoende zijn. 
+De ISO 639:2023 standaard zou aangeschft moeten worden. Hoe gaan we hier mee om ? (https://standards.iteh.ai/catalog/standards/iso/ead9cc68-1fda-4225-add7-a24dabf3f742/iso-639-2023)
+
+Voorstel is om vooralsnog de ISO 639-1:2002 lijst te hanteren. Die is [hier](https://nl.wikipedia.org/wiki/Lijst_van_ISO_639-codes) op te halen. 
+
+Alleen die talen waar een waarde in de kolom "639-1" staat worden opgenomen. 
+
+Als `code` wordt de twee-letterige code in de kolom "639-1"uit de Tabel op [Wikipedia, Lijst van ISO 639-codes]https://nl.wikipedia.org/wiki/Lijst_van_ISO_639-codes) overgenomen.
+
+
+Als `naam` wordt de "Taalnaam" overgenomen.
+
+IndicatieActief wordt standaard op "true" gezet.
+
+## Externe registers
+
+
+
+
+
+
+
+## Soorten object
+
+
+
+## Soorten object-ID

--- a/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/voorbeeldvulling-referentielijsten.md
+++ b/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/voorbeeldvulling-referentielijsten.md
@@ -17,7 +17,7 @@ Tevens is het een goede zaak als gemeenten onderling voor dezelfde referentielij
 
 Per referentielijst wordt aangegeven of, en welke (basis-)vulling er is gedefinieerd en op welke wijze er gemeente-specifieke waarden kunnen worden toegevoegd. 
 
-## Kanalen
+## Kanaal
 
 Vraag uitgezet bij Paul Jansen 
 
@@ -25,7 +25,7 @@ Vraag uitgezet bij Paul Jansen
 | Code | Naam | indicatieActief |
 | :----------- | :----------- | :----------- |
 
-## Landen
+## Land
 
 Voor de referentielijst landen wordt verwezen naar de landelijke tabel 34 zoals die wordt gepubliceerd door de RVIG. 
 De inhoud van deze tabel is beschikbaar op de site van het RVIG onder [Landelijke tabellen](https://publicaties.rvig.nl/Landelijke_tabellen/) 
@@ -35,7 +35,7 @@ Als `landnaam` wordt de "Omschrijving" van de landelijke tabel 34 overgenomen
 Als `ingangsdatumLand` wordt de waarde van "Datum Ingang" van de landelijke tabel 34 overgenomen maar wel volgens de volgens de NEN-ISO 8601:2019-standaard genoteerd.
 Als `einddatumLand` wordt de waarde van "Datum Einde" van de landelijke tabel 34 overgenomen maar wel volgens volgens de NEN-ISO 8601:2019-standaard
 
-## Soorten digitaal adres
+## Soort digitaal adres
 
 Voor de soorten digitaal adres is er geen landelijk standaard waarop we kunnen terugvallen. 
 
@@ -46,16 +46,12 @@ Voorstel voor vulling van de referentielijst "Soorten digitaal adres"
 | 1  | Telefoon | 
 | 2  | E-mail |
 | 3  | Whatsapp |
-| 4  | Brief | 
-| 5  | Web formulier | 
-| 6  | Chat-applicatie | 
-| 7  | Baliebezoek | 
-| 8  | Bezoek op afspraak |
-| 9  | Facebook | 
-| 10 | Instagram | 
+| 4  | Facebook | 
+| 5  | Instagram | 
+| 6  | SMS | 
 
 
-## Talen
+## Taal
 
 Er is een internationale Standaard beschikbaar de ISO 639:2023 standaard. Deze standaard heeft recentelijk de volgende lijst standaarden vervangen : 
 ISO 639-1:2002 - Codes for the representation of names of languages — Part 1: Alpha-2 code
@@ -65,7 +61,7 @@ ISO 639-2:1998 - Codes for the representation of names of languages — Part 2: 
 ISO 639-4:2010 - Codes for the representation of names of languages — Part 4: General principles of coding of the representation of names of languages and related entities, and application guidelines
 
 Voor de talenlijst die hier benodigd is zou ISO 639-1:2002 waarschijnlijk afdoende zijn. 
-De ISO 639:2023 standaard zou aangeschft moeten worden. Hoe gaan we hier mee om ? (https://standards.iteh.ai/catalog/standards/iso/ead9cc68-1fda-4225-add7-a24dabf3f742/iso-639-2023)
+De ISO 639:2023 standaard zou aangeschaft moeten worden. Hoe gaan we hier mee om ? (https://standards.iteh.ai/catalog/standards/iso/ead9cc68-1fda-4225-add7-a24dabf3f742/iso-639-2023)
 
 Voorstel is om vooralsnog de ISO 639-1:2002 lijst te hanteren. Die is [hier](https://nl.wikipedia.org/wiki/Lijst_van_ISO_639-codes) op te halen. 
 
@@ -73,21 +69,63 @@ Alleen die talen waar een waarde in de kolom "639-1" staat worden opgenomen.
 
 Als `code` wordt de twee-letterige code in de kolom "639-1"uit de Tabel op [Wikipedia, Lijst van ISO 639-codes]https://nl.wikipedia.org/wiki/Lijst_van_ISO_639-codes) overgenomen.
 
-
 Als `naam` wordt de "Taalnaam" overgenomen.
 
 IndicatieActief wordt standaard op "true" gezet.
 
-## Externe registers
+## Extern register
 
+De basisvulling ven de referentielijst "Externe registers" omvat alleen de landelijke voorzieningen voor basisregistraties en een voorbeeld van enkele veelvoorkomende gemeentelijke registers. Registers hebben bij verschillende gemeenten verschillende namen. Daarbij komen per gemeente ook meerdere registers van hetzelfde type voor zoals bij Zakenregisters. 
 
+Met de voorbeelvulling willen we ook voorbeelden geven van de samenhang tussen de referentielijsten "Extern register" , "Soort Object" en "Soort ObjectId".
 
+| Code | Naam | Locatie | 
+| :----------- | :----------- | :----------- |
+| 1  | BasisRegistratie Personen |  | 
+| 2  | BasisRegistratie Kadaster |  |
+| 3  | Basisregistratie Adressen en Gebouwen |  |
+| 4  | Basisregistratie Waardering Onroerende Zaken |  | 
+| 5  | HandelsRegister |  | 
+| 6  | Zakenregister |  |
+| 7  | Documentenregister |  |
+| 8  | Overige Objecten Registratie |  |
 
+## Soort object
 
+Met de referentielijst Soorten object wordt in kaart gebracht naar welk soort object binnen een Extern Register verwezen wordt. Hier ligt dus ook een relatie naar de referentietabel Extern Register, want een object "leeft" in een specifiek register. Er kan dus alleen verwezen worden naar objecten die daadwerkelijk in een Ectern Register voorkomen. Deze voorbeeldvulling is zeker niet compleet en kan naar behoefte aangevuld worden. 
 
+| Code | Naam | ExternRegisterId |
+| :----------- | :----------- | :----------- |
+| 1  | Ingeschreven Natuurlijk Persoon | 1 |  | 
+| 2  | Ingeschreven Niet-Natuurlijk Persoon | 5 |
+| 3  | Naampersoon | 5 |
+| 4  | Vestiging | 5 | 
+| 5  | Kadastraal Onroerende Zaak | 2 | 
+| 6  | Persoon | 2 |
+| 7  | Nummeraanduiding | 3 |
+| 8  | Pand | 3 |
+| 9  | WOZ-object | 4 |
+| 10 | Bezwaar | 4 | 
+| 11 | Biljet | 4 | 
+| 12 | Zaak | 6 | 
+| 13 | Betrokkene | 6 | 
+| 14 | Informatieobject | 7 |
 
-## Soorten object
+## Soort object-ID
 
-
-
-## Soorten object-ID
+| Code | Naam | ExternRegisterId |
+| :----------- | :----------- | :----------- |
+| 1  | BurgerServiceNummer (BSN) | 1 |  
+| 2  | Rechtspersonen en Samenwerkingsverbanden Identificatienummer (RSIN) | 2 |
+| 3  | Naampersoon | 5 |
+| 4  | Vestiging | 5 | 
+| 5  | Kadastraal Onroerende Zaak | 2 | 
+| 6  | Persoon | 2 |
+| 7  | Nummeraanduiding | 3 |
+| 8  | Pand | 3 |
+| 9  | WOZ-object | 4 |
+| 10 | Bezwaar | 4 | 
+| 11 | Biljet | 4 | 
+| 12 | Zaak | 6 | 
+| 13 | Betrokkene | 6 | 
+| 14 | Informatieobject | 7 |

--- a/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/voorbeeldvulling-referentielijsten.md
+++ b/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/voorbeeldvulling-referentielijsten.md
@@ -98,7 +98,7 @@ Met de referentielijst Soorten object wordt in kaart gebracht naar welk soort ob
 | :----------- | :----------- | :----------- |
 | 1  | Ingeschreven Natuurlijk Persoon | 1 |  | 
 | 2  | Ingeschreven Niet-Natuurlijk Persoon | 5 |
-| 3  | Naampersoon | 5 |
+| 3  | Informatieobject | 7 |
 | 4  | Vestiging | 5 | 
 | 5  | Kadastraal Onroerende Zaak | 2 | 
 | 6  | Persoon | 2 |
@@ -108,24 +108,22 @@ Met de referentielijst Soorten object wordt in kaart gebracht naar welk soort ob
 | 10 | Bezwaar | 4 | 
 | 11 | Biljet | 4 | 
 | 12 | Zaak | 6 | 
-| 13 | Betrokkene | 6 | 
-| 14 | Informatieobject | 7 |
+
+
 
 ## Soort object-ID
 
-| Code | Naam | ExternRegisterId |
+| Code | Naam | SoortObjectId |
 | :----------- | :----------- | :----------- |
 | 1  | BurgerServiceNummer (BSN) | 1 |  
 | 2  | Rechtspersonen en Samenwerkingsverbanden Identificatienummer (RSIN) | 2 |
-| 3  | Naampersoon | 5 |
-| 4  | Vestiging | 5 | 
-| 5  | Kadastraal Onroerende Zaak | 2 | 
-| 6  | Persoon | 2 |
-| 7  | Nummeraanduiding | 3 |
-| 8  | Pand | 3 |
-| 9  | WOZ-object | 4 |
-| 10 | Bezwaar | 4 | 
-| 11 | Biljet | 4 | 
-| 12 | Zaak | 6 | 
-| 13 | Betrokkene | 6 | 
-| 14 | Informatieobject | 7 |
+| 3  | Vestigingsnummer | 4 | 
+| 4  | Identificatie | 3 | 
+| 6  | Identificatie | 5 |
+| 7  | Identificatie | 6 |
+| 8  | Identificatie | 8 |
+| 9  | wozObjectnummer | 9 |
+| 10 | identificatie | 10 | 
+| 11 | identificatie | 11| 
+| 12 | Zaakidentificatie | 12 | 
+

--- a/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/voorbeeldvulling-referentielijsten.md
+++ b/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/voorbeeldvulling-referentielijsten.md
@@ -128,11 +128,11 @@ Met de voorbeelvulling willen we ook voorbeelden geven van de samenhang tussen d
 
 | Code | Naam | Locatie | 
 | :----------- | :----------- | :----------- |
-| 1  | BasisRegistratie Personen |  | 
-| 2  | BasisRegistratie Kadaster |  |
+| 1  | Basisregistratie Personen |  | 
+| 2  | Basisregistratie Kadaster |  |
 | 3  | Basisregistratie Adressen en Gebouwen |  |
 | 4  | Basisregistratie Waardering Onroerende Zaken |  | 
-| 5  | HandelsRegister |  | 
+| 5  | Handelsregister |  | 
 | 6  | Zakenregister |  |
 | 7  | Documentenregister |  |
 | 8  | Overige Objecten Registratie |  |
@@ -147,30 +147,28 @@ Met de referentielijst Soorten object wordt in kaart gebracht naar welk soort ob
 | 2  | Ingeschreven Niet-Natuurlijk Persoon | 5 |
 | 3  | Informatieobject | 7 |
 | 4  | Vestiging | 5 | 
-| 5  | Kadastraal Onroerende Zaak | 2 | 
+| 5  | Onroerende zaak | 2 | 
 | 6  | Persoon | 2 |
 | 7  | Nummeraanduiding | 3 |
 | 8  | Pand | 3 |
-| 9  | WOZ-object | 4 |
+| 9  | WOZObject | 4 |
 | 10 | Bezwaar | 4 | 
 | 11 | Biljet | 4 | 
 | 12 | Zaak | 6 | 
-
-
 
 ## Soort object-ID
 
 | Code | Naam | SoortObjectId |
 | :----------- | :----------- | :----------- |
-| 1  | BurgerServiceNummer (BSN) | 1 |  
-| 2  | Rechtspersonen en Samenwerkingsverbanden Identificatienummer (RSIN) | 2 |
+| 1  | Burgerservicenummer | 1 |  
+| 2  | Rechtspersonen en Samenwerkingsverbanden Identificatienummer | 2 |
 | 3  | Vestigingsnummer | 4 | 
 | 4  | Identificatie | 3 | 
 | 6  | Identificatie | 5 |
 | 7  | Identificatie | 6 |
 | 8  | Identificatie | 8 |
-| 9  | wozObjectnummer | 9 |
-| 10 | identificatie | 10 | 
-| 11 | identificatie | 11| 
+| 9  | WozObjectnummer | 9 |
+| 10 | Identificatie | 10 | 
+| 11 | Identificatie | 11| 
 | 12 | Zaakidentificatie | 12 | 
 

--- a/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/voorbeeldvulling-referentielijsten.md
+++ b/docs/api_familie_klantinteracties/klantinteracties_referentielijsten/voorbeeldvulling-referentielijsten.md
@@ -19,7 +19,7 @@ Per referentielijst wordt aangegeven of, en welke (basis-)vulling er is gedefini
 
 ## Kanaal
 
-Vraag uitgezet bij Paul Jansen 
+Vraag uitgezet bij Paul Jansen / Vincent van Beek
 
 
 | Code | Naam | indicatieActief |
@@ -63,11 +63,62 @@ Voor het samenstellen van de lijst worden de volgende criteria gehanteerd :
 Dat leidt tot de volgende voorbeeldvulling van de referentielijst
 
 | **Code** | **Naam** | **IndicatieActief** | 
-
-
-Als `naam` wordt de "Taalnaam" overgenomen.
-
-IndicatieActief wordt standaard op "true" gezet.
+| ---- | ---- | ---- | 
+| ara  | Arabisch | true | 
+| aze  | Azerbeidzjaans | true | 
+| bel  | Belarussisch | true | 
+| ber  | Berber | true | 
+| bos  | Bosnisch | true | 
+| bul  | Bulgaars | true | 
+| ces  | Tsjechisch | true | 
+| cnr  | Montenegrijns | true | 
+| dan  | Deens | true | 
+| deu  | Duits | true | 
+| ell  | Grieks | true | 
+| eng  | Engels | true | 
+| est  | Estisch | true | 
+| fas  | Perzisch | true | 
+| fin  | Fins | true | 
+| fra  | Frans | true | 
+| fry  | Fries | true | 
+| gle  | Iers | true | 
+| hin  | Hindi | true | 
+| hrv  | Kroatisch | true | 
+| hun  | Hongaars | true | 
+| hye  | Armeens | true | 
+| isl  | IJslands | true | 
+| ita  | Italiaans | true | 
+| jav  | Javaans | true | 
+| lav  | Lets | true | 
+| lim  | Limburgs | true | 
+| lit  | Litouwen | true | 
+| kat  | Georgisch | true | 
+| kur  | Koerdisch | true | 
+| mlt  | Maltees | true | 
+| mkd  | Macedonisch | true | 
+| nds  | Nedersaksisch | true | 
+| nld  | Nederlands | true | 
+| nor  | Noors | true | 
+| pap  | Papiaments | true | 
+| pol  | Pools | true | 
+| por  | Portugees | true | 
+| rom  | Romani | true | 
+| ron  | Roemeens | true | 
+| rus  | Russisch | true | 
+| sgn  | Gebarentaal | true | 
+| slk  | Slowaaks | true | 
+| slv  | Sloveens | true | 
+| som  | Somalisch | true | 
+| spa  | Spaans | true | 
+| srn  | Sranan | true | 
+| srp  | Servisch | true | 
+| sqi  | Albanees | true | 
+| swe  | Zweeds | true | 
+| tur  | Turks | true | 
+| ukr  | Oekraïens | true | 
+| yue  | Kantonees  | true | 
+| yid  | Jiddisch | true | 
+| zho  | Mandarijn | true | 
 
 ## Extern register
 


### PR DESCRIPTION
Ik heb vooralsnog alleen een voorstel voor de referentielijsten gedaan in een beschrijving. Als we hierover akkoord zijn moeten de bijbehorende wijzigingen in de OAS worden doorgevoerd. ( De verwijzing van Soort objectId naar Soort object en de verwijzing van Soort Object naar Extern Register.)